### PR TITLE
DBP-494-ensure-latest-image-on-branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,33 @@ jobs:
           wget https://github.com/dBildungsplattform/helm-charts-registry/releases/download/${{ needs.find_dbildungs_iam_keycloak_helm_chart_tag.outputs.helm_chart_tagname }}/${{ needs.find_dbildungs_iam_keycloak_helm_chart_tag.outputs.helm_chart_tagname }}.tgz
           tar -zxvf ${{ needs.find_dbildungs_iam_keycloak_helm_chart_tag.outputs.helm_chart_tagname }}.tgz 
 
+      - name: Uninstall dbildungs_iam_client Helm chart (dev branch)
+        if: ${{ inputs.dbildungs_iam_client_branch != 'main' }}
+        run: |
+          helm uninstall \
+            spsh-client \
+            --namespace ${{ inputs.namespace }} \
+            --kubeconfig $(pwd)/kubeconfig \
+            --ignore-not-found
+
+      - name: Uninstall dbildungs_iam_server Helm chart (dev branch)
+        if: ${{ inputs.dbildungs_iam_server_branch != 'main' }}
+        run: |
+          helm uninstall \
+            dbildungs-iam \
+            --namespace ${{ inputs.namespace }} \
+            --kubeconfig $(pwd)/kubeconfig \
+            --ignore-not-found
+
+      - name: Uninstall dbildungs_iam_keycloak Helm chart (dev branch)
+        if: ${{ inputs.dbildungs_iam_keycloak_branch != 'main' }}
+        run: |
+          helm uninstall \
+            dbildungscloud-iam-keycloak \
+            --namespace ${{ inputs.namespace }} \
+            --kubeconfig $(pwd)/kubeconfig \
+            --ignore-not-found
+
       - name: Deploy dbildungs_iam_client Helm chart
         run: |
           helm upgrade --install \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,8 @@ jobs:
           wget https://github.com/dBildungsplattform/helm-charts-registry/releases/download/${{ needs.find_dbildungs_iam_keycloak_helm_chart_tag.outputs.helm_chart_tagname }}/${{ needs.find_dbildungs_iam_keycloak_helm_chart_tag.outputs.helm_chart_tagname }}.tgz
           tar -zxvf ${{ needs.find_dbildungs_iam_keycloak_helm_chart_tag.outputs.helm_chart_tagname }}.tgz 
 
+      # On branches the ticket number is used as image tag. To ensure the pods are restarted
+      # and pull the the latest image, we uninstall the helm release first. (Otherwise same tag -> no change)
       - name: Uninstall dbildungs_iam_client Helm chart (dev branch)
         if: ${{ inputs.dbildungs_iam_client_branch != 'main' }}
         run: |


### PR DESCRIPTION
# Description
The tag for images from branches is the ticket number. If only the image changes, helm upgrade won't detect a change (same tag), the pod is not restarted and doesn't pull the new image.
To ensure that the pods always use the latest image of the branch, the workflow uninstalls the helm release first now.
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
[DBP-494](https://ticketsystem.dbildungscloud.de/browse/DBP-494)
<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.