### PR TITLE
dbp-608-Fixed commit SHA for external Jobs

### DIFF
--- a/.github/workflows/delete-namespace-manual.yml
+++ b/.github/workflows/delete-namespace-manual.yml
@@ -20,7 +20,7 @@ jobs:
   delete_namespace:
     needs: 
       - check_namespace_input
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/delete-namespace.yml@dbp-608-Fixed-commit-SHA-for-external-Jobs
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/delete-namespace.yml@main
     with:
       namespace: ${{ github.event.inputs.namespace }}
     secrets:

--- a/.github/workflows/delete-namespace-manual.yml
+++ b/.github/workflows/delete-namespace-manual.yml
@@ -20,7 +20,7 @@ jobs:
   delete_namespace:
     needs: 
       - check_namespace_input
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/delete-namespace.yml@main
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/delete-namespace.yml@dbp-608-Fixed-commit-SHA-for-external-Jobs
     with:
       namespace: ${{ github.event.inputs.namespace }}
     secrets:

--- a/.github/workflows/delete-namespace.yml
+++ b/.github/workflows/delete-namespace.yml
@@ -63,12 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  #v4.1.1
       with:
         repository: 'dBildungsplattform/spsh-app-deploy'
 
     - name: Set up kubectl and Helm
-      uses: azure/setup-kubectl@v3
+      uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f #v4.0.0
 
     - name: Configure kubeconfig as tmp file
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,12 +117,12 @@ jobs:
           [[ ${{ inputs.namespace }} =~ $regex ]]
           echo "${BASH_REMATCH[1]}"
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
           repository: 'dBildungsplattform/spsh-app-deploy'
 
       - name: Set up kubectl and Helm
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f #v4.0.0
 
       - name: Configure kubeconfig as tmp file
         run: |

--- a/.github/workflows/find-helm-chart-by-ticket-or-main-in-registry.yml
+++ b/.github/workflows/find-helm-chart-by-ticket-or-main-in-registry.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Search ${{ inputs.service_name }} and get Helm Chart release by ticket name with releaseNameRegEx action
         if: ${{ github.ref_name != 'main' }}
         id: getByReleaseNameRegEx
-        uses: cardinalby/git-get-release-action@1.2.4
+        uses: cardinalby/git-get-release-action@cedef2faf69cb7c55b285bad07688d04430b7ada  #1.2.4
         with:
           releaseNameRegEx: "${{ inputs.chart_name }}-0.0.0-${{ inputs.branch }}"
           searchLimit: 1000
@@ -53,7 +53,7 @@ jobs:
       - name: Check if a Branch Helm Chart was found, if not, take last from main
         if: ${{ steps.getByReleaseNameRegEx.outputs.tag_name == '' || github.ref_name == 'main'  }}
         id: getMainByReleaseNameRegEx
-        uses: cardinalby/git-get-release-action@1.2.4
+        uses: cardinalby/git-get-release-action@cedef2faf69cb7c55b285bad07688d04430b7ada #1.2.4
         with:
           releaseNameRegEx: "${{ inputs.chart_name }}-0.0.1"
           doNotFailIfNotFound: 'true'


### PR DESCRIPTION
For external jobs, it is recommended to use fixed commit SHA references.

TODO:

Identify all external jobs currently referenced in our CI/CD workflows.
Update the workflow configurations to reference the external jobs using their respective commit SHAs instead of semantic versions.
AC:

All references to external jobs in the CI/CD workflows must use a fixed commit SHA.
 

# Description

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.