### PR TITLE
Dbp 593 fix manual deployment

### DIFF
--- a/.github/workflows/deploy-to-dev-manual.yml
+++ b/.github/workflows/deploy-to-dev-manual.yml
@@ -47,7 +47,7 @@ jobs:
     needs:
       - check_namespace_input
       - create_branch_identifier
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@main
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@DBP-593-Fix-manual-deployment
     with:
       dbildungs_iam_server_branch: ${{ github.event.inputs.dbildungs_iam_server_branch }}
       dbildungs_iam_client_branch: ${{ github.event.inputs.dbildungs_iam_client_branch }}

--- a/.github/workflows/deploy-to-dev-manual.yml
+++ b/.github/workflows/deploy-to-dev-manual.yml
@@ -35,11 +35,13 @@ jobs:
       - create_branch_identifier
     runs-on: ubuntu-latest
     steps:
-    - name: Check if namespace is allowed, fails if it not starts with ticketnr, e.g. spsh-1234
+    - name: Check if namespace is allowed, fails if it not starts with ticketnr, e.g. spsh-1234 or is exactly 'main'
       run: | 
-        regex='^([[:alpha:]]+?-[[:digit:]]+)'
-        [[ ${{ needs.create_branch_identifier.outputs.namespace_from_branch }} =~ $regex ]]
-        echo "${BASH_REMATCH[1]}"
+          if ${{ github.event.inputs.namespace != 'main' }}; then
+            regex='^([[:alpha:]]+?-[[:digit:]]+)'
+            [[ ${{ github.event.inputs.namespace }} =~ $regex ]]
+            echo "${BASH_REMATCH[1]}"
+          fi
 
   deploy:
     needs:

--- a/.github/workflows/deploy-to-dev-manual.yml
+++ b/.github/workflows/deploy-to-dev-manual.yml
@@ -47,7 +47,7 @@ jobs:
     needs:
       - check_namespace_input
       - create_branch_identifier
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@DBP-593-Fix-manual-deployment
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@main
     with:
       dbildungs_iam_server_branch: ${{ github.event.inputs.dbildungs_iam_server_branch }}
       dbildungs_iam_client_branch: ${{ github.event.inputs.dbildungs_iam_client_branch }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,9 +105,9 @@ jobs:
     steps:
       - name: Check if namespace is allowed, fails if it not starts with ticketnr, e.g. spsh-1234 or is exactly 'main'
         run: | 
-            if ${{ github.event.inputs.namespace != 'main' }}; then
+            if ${{ inputs.namespace != 'main' }}; then
               regex='^([[:alpha:]]+?-[[:digit:]]+)'
-              [[ ${{ github.event.inputs.namespace }} =~ $regex ]]
+              [[ ${{ inputs.namespace }} =~ $regex ]]
               echo "${BASH_REMATCH[1]}"
             fi
       - name: checkout repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,6 @@ name: Deploy Action
 on:
   workflow_call:
     inputs:
-      #branch:
-      #  required: true
-      #  type: string
       namespace:
         required: true
         type: string
@@ -60,15 +57,10 @@ jobs:
       chart_name: "dbildungscloud-iam-keycloak"
       service_name: "dbildungs-iam-keycloak"
 
-  create_ingress_prefix:
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/get-branch-meta.yml@main
-
   create_lowercase_ingress_prefix:
-    needs:
-      - create_ingress_prefix
     uses: dBildungsplattform/spsh-app-deploy/.github/workflows/branch-to-namespace.yml@main
     with:
-      branch: ${{ needs.create_ingress_prefix.outputs.ticket }}
+      branch: ${{ inputs.namespace }}
 
   create_keycloak_db_name:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,11 +103,13 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
       KUBECONFIG_FILE: '${{ secrets.SPSH_DEV_KUBECONFIG }}'
     steps:
-      - name: Check if namespace is allowed, fails if it not starts with ticketnr, e.g. spsh-1234
+      - name: Check if namespace is allowed, fails if it not starts with ticketnr, e.g. spsh-1234 or is exactly 'main'
         run: | 
-          regex='^([[:alpha:]]+?-[[:digit:]]+)'
-          [[ ${{ inputs.namespace }} =~ $regex ]]
-          echo "${BASH_REMATCH[1]}"
+            if ${{ github.event.inputs.namespace != 'main' }}; then
+              regex='^([[:alpha:]]+?-[[:digit:]]+)'
+              [[ ${{ github.event.inputs.namespace }} =~ $regex ]]
+              echo "${BASH_REMATCH[1]}"
+            fi
       - name: checkout repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
fix manual deployment
Problem was that the deployment workflow tried to get the ticketnr. by getting the branch name itself, this does not work for manual deployment. The deployment workflow should take the namespace input variable for generating the ticketnr.

# Description

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.