### PR TITLE
DBP-701 Remove pending Helm charts, wait for charts to be removed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,7 +155,8 @@ jobs:
           LIST_OF_HELM_CHARTS_IN_NAMESPACE="$(helm ls \
           --namespace ${{ inputs.namespace }} \
           --kubeconfig $(pwd)/kubeconfig \
-          --short)"
+          --short \
+          --all)"
 
           # Check if list of installed Helm-Charts is empty 
           if [ -z "$LIST_OF_HELM_CHARTS_IN_NAMESPACE" ]; then
@@ -164,7 +165,8 @@ jobs:
             helm uninstall \
               $LIST_OF_HELM_CHARTS_IN_NAMESPACE \
               --namespace ${{ inputs.namespace }} \
-              --kubeconfig $(pwd)/kubeconfig
+              --kubeconfig $(pwd)/kubeconfig \
+              --wait
           fi
 
       - name: Create dbildungs-iam-server secret


### PR DESCRIPTION
# Description
Without the --all flag helm ls will hide pending charts. Without --wait we may try to install a Helm chart before it is completely uninstalled.
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.