### PR TITLE
Dbp 853 switch for dbseeding

### DIFF
--- a/.github/workflows/deploy-to-dev-manual.yml
+++ b/.github/workflows/deploy-to-dev-manual.yml
@@ -56,7 +56,7 @@ jobs:
     needs:
       - check_namespace_input
       - create_branch_identifier
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@DBP-853-switch-for-dbseeding
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@4
     with:
       dbildungs_iam_server_branch: ${{ github.event.inputs.dbildungs_iam_server_branch }}
       schulportal_client_branch: ${{ github.event.inputs.dbildungs_iam_client_branch }}

--- a/.github/workflows/deploy-to-dev-manual.yml
+++ b/.github/workflows/deploy-to-dev-manual.yml
@@ -23,6 +23,14 @@ on:
         description: "dbildungs_iam_keycloak Branch. Has to be main or in format <project>-<ticketnumber>, e.g. spsh-130"
         default: main
         type: string
+      dbseeding:
+        required: true
+        description: "DB-Seeding (Default: chart_value)"
+        default: "chart_value"
+        type: choice
+        - chart_value
+        - true
+        - false
 
 jobs:
   create_branch_identifier:
@@ -52,6 +60,7 @@ jobs:
       dbildungs_iam_server_branch: ${{ github.event.inputs.dbildungs_iam_server_branch }}
       schulportal_client_branch: ${{ github.event.inputs.dbildungs_iam_client_branch }}
       dbildungs_iam_keycloak_branch: ${{ github.event.inputs.dbildungs_iam_keycloak_branch }}
+      dbseeding: ${{ github.event.inputs.dbseeding }}
       namespace: ${{ needs.create_branch_identifier.outputs.namespace_from_branch }}
       user_name: spsh-bot
     secrets:

--- a/.github/workflows/deploy-to-dev-manual.yml
+++ b/.github/workflows/deploy-to-dev-manual.yml
@@ -28,9 +28,10 @@ on:
         description: "DB-Seeding (Default: chart_value)"
         default: "chart_value"
         type: choice
-          - "chart_value"
-          - "true"
-          - "false"
+        options:
+        - "chart_value"
+        - "true"
+        - "false"
 
 jobs:
   create_branch_identifier:

--- a/.github/workflows/deploy-to-dev-manual.yml
+++ b/.github/workflows/deploy-to-dev-manual.yml
@@ -28,9 +28,9 @@ on:
         description: "DB-Seeding (Default: chart_value)"
         default: "chart_value"
         type: choice
-        - chart_value
-        - true
-        - false
+          - "chart_value"
+          - "true"
+          - "false"
 
 jobs:
   create_branch_identifier:
@@ -55,7 +55,7 @@ jobs:
     needs:
       - check_namespace_input
       - create_branch_identifier
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@2
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@DBP-853-switch-for-dbseeding
     with:
       dbildungs_iam_server_branch: ${{ github.event.inputs.dbildungs_iam_server_branch }}
       schulportal_client_branch: ${{ github.event.inputs.dbildungs_iam_client_branch }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,11 @@ on:
         description: "Has to be main or in format <project>-<ticketnumber>, e.g. spsh-130"
         default: main
         type: string
+      dbseeding:
+        required: false
+        description: "Enable Seeding (true, false, chart_value)"
+        default: chart_value
+        type: string
     secrets:
       SPSH_DEV_KUBECONFIG:
         required: true
@@ -243,6 +248,7 @@ jobs:
             --set backendHostname=${{ needs.create_lowercase_ingress_prefix.outputs.namespace_from_branch }}.dev.spsh.dbildungsplattform.de \
             --set keycloakHostname=${{ needs.create_lowercase_ingress_prefix.outputs.namespace_from_branch }}-keycloak.dev.spsh.dbildungsplattform.de \
             --set database.name=${{ needs.create_dbildungs_iam_server_db_name.outputs.server_db_name }} \
+            ${{ inputs.dbseeding != 'chart_value' && format('--set backend.dbseeding.enabled={0}', inputs.dbseeding) || '' }} \
             --wait
   
   determine_playwright_branch:


### PR DESCRIPTION
# Description
Add switch to enabled/disable the database seeding to the workflows.
The change is backwards compatible: If the new input is not used, the value defined in the chart is used.
Planned tag: 4.1.0
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
[DBP-853](https://ticketsystem.dbildungscloud.de/browse/DBP-853)
<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.