### PR TITLE
Dbp-1179-convert-branch-to-image-tag-and-chart-version

### DIFF
--- a/.github/workflows/convert-branch-name.yml
+++ b/.github/workflows/convert-branch-name.yml
@@ -11,33 +11,30 @@ on:
     outputs:
       namespace_from_branch:
         description: "Branch in namespace compatible fashion"
-        value: ${{ jobs.convert_branch_name_to_namespace.outputs.namespace_from_branch }}
+        value: ${{ jobs.convert_branch_name.outputs.namespace_from_branch }}
       image_tag_from_branch:
         description: "Image tag from branch"
-        value: ${{ jobs.convert_branch_name_to_image_tag.outputs.image_tag }}
+        value: ${{ jobs.convert_branch_name.outputs.image_tag }}
       chart_version_from_branch:
         description: "Chart version from branch"
-        value: ${{ jobs.convert_branch_name_to_chart_version.outputs.chart_version }}
+        value: ${{ jobs.convert_branch_name.outputs.chart_version }}
 
 jobs:
-  convert_branch_name_to_namespace:
+  convert_branch_name:
     runs-on: ubuntu-latest
     outputs:
-      namespace_from_branch: ${{ steps.create_branch_identifier.outputs.namespace_from_branch }}
+      namespace_from_branch: ${{ steps.create_namespace.outputs.namespace_from_branch }}
+      image_tag: ${{ steps.create_image_tag.outputs.image_tag }}
+      chart_version: ${{ steps.create_chart_version.outputs.chart_version }}
     # This step will match and return either text-1234 or text-1234-1234 from the input branch name
     steps:
-      - id: create_branch_identifier
+      - id: create_namespace
         shell: bash
         run: |
           temp=$(echo ${{ inputs.branch }} | sed 's@.*/@@' | tr [A-Z] [a-z] | tr _ - | tr \. - | sed 's/\([[:alpha:]]*-[[:digit:]]*-[[:digit:]]*\).*/\1/' | sed 's/-*$//' | cut -c1-63)
           echo "before:" ${{ inputs.branch }} "-- after: $temp"
           echo "namespace_from_branch=$temp" >> $GITHUB_OUTPUT
-  
-  convert_branch_name_to_image_tag:
-    runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.create_image_tag.outputs.image_tag }}
-    steps:
+      
       - id: create_image_tag
         run: |
           regex_long='^([[:alpha:]]+?-[[:digit:]]+-[[:digit:]]+)'
@@ -53,20 +50,14 @@ jobs:
             exit 1
           fi
           echo "image_tag=${tag}" >> "$GITHUB_OUTPUT"
-
-  convert_branch_name_to_chart_version:
-    needs:
-      - convert_branch_name_to_image_tag
-    runs-on: ubuntu-latest
-    outputs:
-      chart_version: ${{ steps.create_chart_version.outputs.chart_version }}
-    steps:
+      
       - id: create_chart_version
         run: |
           timestamp=`echo $(date +'%Y%m%d-%H%M')`
           if [[ "${{ inputs.branch }}" == 'main' ]]; then
             chart_version=""
           else
-            chart_version="0.0.0-$(echo ${{ needs.convert_branch_name_to_image_tag.outputs.image_tag }} | tr [A-Z] [a-z])-${timestamp}"
+            chart_version="0.0.0-$(echo ${{ steps.create_image_tag.outputs.image_tag }} | tr [A-Z] [a-z])-${timestamp}"
           fi
           echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+      

--- a/.github/workflows/convert-branch-name.yml
+++ b/.github/workflows/convert-branch-name.yml
@@ -57,7 +57,7 @@ jobs:
           if [[ "${{ inputs.branch }}" == 'main' ]]; then
             chart_version=""
           else
-            chart_version="0.0.0-" ${{ steps.create_image_tag.outputs.image_tag }} "-${timestamp}"
+            chart_version="0.0.0-${{ steps.create_image_tag.outputs.image_tag }}-${timestamp}"
           fi
           echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
       

--- a/.github/workflows/convert-branch-name.yml
+++ b/.github/workflows/convert-branch-name.yml
@@ -40,9 +40,9 @@ jobs:
           regex_long='^([[:alpha:]]+?-[[:digit:]]+-[[:digit:]]+)'
           regex_short='^([[:alpha:]]+?-[[:digit:]]+)'
           if [[ "${{ inputs.branch }}" =~ $regex_long ]]; then
-            tag="${BASH_REMATCH[1]}"
+            tag="$(echo '${BASH_REMATCH[1]}' | tr [A-Z] [a-z])"
           elif [[ "${{ inputs.branch }}" =~ $regex_short ]]; then
-            tag="${BASH_REMATCH[1]}"
+            tag="$(echo '${BASH_REMATCH[1]}' | tr [A-Z] [a-z])"
           elif [[ "${{ inputs.branch }}" == 'main' ]]; then
             tag=""
           else
@@ -57,7 +57,7 @@ jobs:
           if [[ "${{ inputs.branch }}" == 'main' ]]; then
             chart_version=""
           else
-            chart_version="0.0.0-$(echo ${{ steps.create_image_tag.outputs.image_tag }} | tr [A-Z] [a-z])-${timestamp}"
+            chart_version="0.0.0-" ${{ steps.create_image_tag.outputs.image_tag }} "-${timestamp}"
           fi
           echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
       

--- a/.github/workflows/convert-branch-name.yml
+++ b/.github/workflows/convert-branch-name.yml
@@ -40,9 +40,9 @@ jobs:
           regex_long='^([[:alpha:]]+?-[[:digit:]]+-[[:digit:]]+)'
           regex_short='^([[:alpha:]]+?-[[:digit:]]+)'
           if [[ "${{ inputs.branch }}" =~ $regex_long ]]; then
-            tag="$(echo '${BASH_REMATCH[1]}' | tr [A-Z] [a-z])"
+            tag="$(echo ${BASH_REMATCH[1]} | tr [A-Z] [a-z])"
           elif [[ "${{ inputs.branch }}" =~ $regex_short ]]; then
-            tag="$(echo '${BASH_REMATCH[1]}' | tr [A-Z] [a-z])"
+            tag="$(echo ${BASH_REMATCH[1]} | tr [A-Z] [a-z])"
           elif [[ "${{ inputs.branch }}" == 'main' ]]; then
             tag=""
           else

--- a/.github/workflows/convert-branch-name.yml
+++ b/.github/workflows/convert-branch-name.yml
@@ -34,7 +34,6 @@ jobs:
           echo "namespace_from_branch=$temp" >> $GITHUB_OUTPUT
   
   convert_branch_name_to_image_tag:
-    name: "Convert branch name to image tag"
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.create_image_tag.outputs.image_tag }}
@@ -56,7 +55,6 @@ jobs:
           echo "image_tag=${tag}" >> "$GITHUB_OUTPUT"
 
   convert_branch_name_to_chart_version:
-    name: "Convert branch name to chart version"
     needs:
       - convert_branch_name_to_image_tag
     runs-on: ubuntu-latest

--- a/.github/workflows/convert-branch-name.yml
+++ b/.github/workflows/convert-branch-name.yml
@@ -5,16 +5,22 @@ on:
   workflow_call:
     inputs:
       branch:
-        description: "original branch name"
+        description: "Original branch name"
         required: true
         type: string
     outputs:
       namespace_from_branch:
-        description: "branch in namespace compatible fashion"
-        value: ${{ jobs.convert_branch_name.outputs.namespace_from_branch }}
+        description: "Branch in namespace compatible fashion"
+        value: ${{ jobs.convert_branch_name_to_namespace.outputs.namespace_from_branch }}
+      image_tag_from_branch:
+        description: "Image tag from branch"
+        value: ${{ jobs.convert_branch_name_to_image_tag.outputs.image_tag }}
+      chart_version_from_branch:
+        description: "Chart version from branch"
+        value: ${{ jobs.convert_branch_name_to_chart_version.outputs.chart_version }}
 
 jobs:
-  convert_branch_name:
+  convert_branch_name_to_namespace:
     runs-on: ubuntu-latest
     outputs:
       namespace_from_branch: ${{ steps.create_branch_identifier.outputs.namespace_from_branch }}
@@ -26,3 +32,43 @@ jobs:
           temp=$(echo ${{ inputs.branch }} | sed 's@.*/@@' | tr [A-Z] [a-z] | tr _ - | tr \. - | sed 's/\([[:alpha:]]*-[[:digit:]]*-[[:digit:]]*\).*/\1/' | sed 's/-*$//' | cut -c1-63)
           echo "before:" ${{ inputs.branch }} "-- after: $temp"
           echo "namespace_from_branch=$temp" >> $GITHUB_OUTPUT
+  
+  convert_branch_name_to_image_tag:
+    name: "Convert branch name to image tag"
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.create_image_tag.outputs.image_tag }}
+    steps:
+      - id: create_image_tag
+        run: |
+          regex_long='^([[:alpha:]]+?-[[:digit:]]+-[[:digit:]]+)'
+          regex_short='^([[:alpha:]]+?-[[:digit:]]+)'
+          if [[ "${{ inputs.branch }}" =~ $regex_long ]]; then
+            tag="${BASH_REMATCH[1]}"
+          elif [[ "${{ inputs.branch }}" =~ $regex_short ]]; then
+            tag="${BASH_REMATCH[1]}"
+          elif [[ "${{ inputs.branch }}" == 'main' ]]; then
+            tag=""
+          else
+          echo "::error::Couldn't extract ticket from branch" ${{ inputs.branch }} ". If not main the branch name should begin alpha-digit or alpha-digit-digit blocks (e.g. SPSH-1234-test-name or release-1-1-optional-text)"
+            exit 1
+          fi
+          echo "image_tag=${tag}" >> "$GITHUB_OUTPUT"
+
+  convert_branch_name_to_chart_version:
+    name: "Convert branch name to chart version"
+    needs:
+      - convert_branch_name_to_image_tag
+    runs-on: ubuntu-latest
+    outputs:
+      chart_version: ${{ steps.create_chart_version.outputs.chart_version }}
+    steps:
+      - id: create_chart_version
+        run: |
+          timestamp=`echo $(date +'%Y%m%d-%H%M')`
+          if [[ "${{ inputs.branch }}" == 'main' ]]; then
+            chart_version=""
+          else
+            chart_version="0.0.0-$(echo ${{ needs.convert_branch_name_to_image_tag.outputs.image_tag }} | tr [A-Z] [a-z])-${timestamp}"
+          fi
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/convert-branch-name.yml
+++ b/.github/workflows/convert-branch-name.yml
@@ -11,7 +11,7 @@ on:
     outputs:
       namespace_from_branch:
         description: "Branch in namespace compatible fashion"
-        value: ${{ jobs.convert_branch_name.outputs.namespace_from_branch }}
+        value: ${{ jobs.convert_branch_name.outputs.namespace }}
       image_tag_from_branch:
         description: "Image tag from branch"
         value: ${{ jobs.convert_branch_name.outputs.image_tag }}
@@ -23,17 +23,17 @@ jobs:
   convert_branch_name:
     runs-on: ubuntu-latest
     outputs:
-      namespace_from_branch: ${{ steps.create_namespace.outputs.namespace_from_branch }}
+      namespace: ${{ steps.create_namespace_identifier.outputs.namespace }}
       image_tag: ${{ steps.create_image_tag.outputs.image_tag }}
       chart_version: ${{ steps.create_chart_version.outputs.chart_version }}
     # This step will match and return either text-1234 or text-1234-1234 from the input branch name
     steps:
-      - id: create_namespace
+      - id: create_namespace_identifier
         shell: bash
         run: |
           temp=$(echo ${{ inputs.branch }} | sed 's@.*/@@' | tr [A-Z] [a-z] | tr _ - | tr \. - | sed 's/\([[:alpha:]]*-[[:digit:]]*-[[:digit:]]*\).*/\1/' | sed 's/-*$//' | cut -c1-63)
           echo "before:" ${{ inputs.branch }} "-- after: $temp"
-          echo "namespace_from_branch=$temp" >> $GITHUB_OUTPUT
+          echo "namespace=$temp" >> $GITHUB_OUTPUT
       
       - id: create_image_tag
         run: |

--- a/.github/workflows/get-branch-meta.yml
+++ b/.github/workflows/get-branch-meta.yml
@@ -3,15 +3,14 @@ on:
   workflow_call:
     outputs:
       branch:
-        description: "branch name"
+        description: "Branch name"
         value: ${{ jobs.branch_meta.outputs.branch }}
       sha:
-        description: "sha of the branch"
+        description: "SHA of the branch"
         value: ${{ jobs.branch_meta.outputs.sha }}
       ticket:
-        description: "ticketnr of the branchname"
+        description: "Ticketnr of the branchname"
         value: ${{ jobs.branch_meta.outputs.ticket }}
-
 
 jobs:
   branch_meta:
@@ -35,10 +34,13 @@ jobs:
       - name: Extract project-ticketnumber from branch
         id: extract_branch_ticket
         run: |
+          regex_long='^([[:alpha:]]+?-[[:digit:]]+-[[:digit:]]+)'
+          regex_short='^([[:alpha:]]+?-[[:digit:]]+)'
           if ${{ github.ref_name == 'main' }}; then
-            echo "ticket=main" >> $GITHUB_OUTPUT
-          else
-            regex='^([[:alpha:]]+?-[[:digit:]]+)'
-            [[ ${{ steps.extract_branch_meta.outputs.branch }} =~ $regex ]]
-            echo "ticket=$(echo ${BASH_REMATCH[1]} | tr [A-Z] [a-z])" >> $GITHUB_OUTPUT
+            ticket="main"
+          elif [[ "${{ github.ref_name }}" =~ $regex_long ]]; then
+            ticket="$(echo ${BASH_REMATCH[1]} | tr [A-Z] [a-z])"
+          elif [[ "${{ github.ref_name }}" =~ $regex_short ]]; then
+            ticket="$(echo ${BASH_REMATCH[1]} | tr [A-Z] [a-z])"
           fi
+          echo "ticket=${ticket}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Description

- this PR enhances the convert-branch-name.yml workflow so that it also converts the branch name into a proper image tag and chart version used in spsh context
- the image tag and chart version may consist of **alpha-digit** or **alpha-digit-digit** blocks, so e.g. release-1-1 as image tag and chart version is possible now
- the new main state will be tagged with 6, 6.0, 6.0.0
- image tags will now be in lower case per default for more consistency
- get-branch-meta will now return a ticket number with **alpha-digit-digit**, **alpha-digit blocks** or "main"

successfully tested here:

- alpha-digit: https://github.com/dBildungsplattform/dbildungs-iam-keycloak/actions/runs/12355705924 
- alpha-digit-digit: https://github.com/dBildungsplattform/dbildungs-iam-keycloak/actions/runs/12355713301

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.